### PR TITLE
Raise specific exceptions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: ruby
+rvm:
+  - 1.8.7
+  - jruby-18mode
+  - 1.9.3
+  - jruby-19mode
+  - 2.1.0
+  - rbx

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org/'
+
+gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,18 @@
+PATH
+  remote: .
+  specs:
+    data_uri (0.0.3)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    minitest (5.2.3)
+    rake (10.1.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  data_uri!
+  minitest
+  rake

--- a/README.rdoc
+++ b/README.rdoc
@@ -1,4 +1,4 @@
-= Data URI
+= Data URI {<img src="https://travis-ci.org/porras/data_uri.png?branch=update" alt="Build Status" />}[https://travis-ci.org/porras/data_uri]
 
 == Introduction
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,9 @@
+require 'rake/testtask'
+Rake::TestTask.new
+task :default => :test
+
 desc "Build a gem file"
 task :build do
   system "gem build data_uri.gemspec"
 end
+

--- a/data_uri.gemspec
+++ b/data_uri.gemspec
@@ -13,4 +13,7 @@ Gem::Specification.new do |s|
 
   s.require_path = 'lib'
   s.files = %w(README.rdoc Rakefile) + Dir.glob("lib/**/*")
+
+  s.add_development_dependency 'rake'
+  s.add_development_dependency 'minitest'
 end

--- a/lib/data_uri/uri.rb
+++ b/lib/data_uri/uri.rb
@@ -12,7 +12,7 @@ module URI
       if args.length == 1
         uri = args.first.to_s
         unless uri.match(/^data:/)
-          raise 'Invalid Data URI: ' + args.first.inspect
+          raise URI::InvalidURIError.new('Invalid Data URI: ' + args.first.inspect)
         end
         @scheme = 'data'
         @opaque = uri[5 .. -1]
@@ -34,7 +34,7 @@ module URI
         @data = @data[7 .. -1]
       end
       unless /^,/.match(@data)
-        raise 'Invalid data URI'
+        raise URI::InvalidURIError.new('Invalid data URI')
       end
       @data = @data[1 .. -1]
       @data = base64 ? Base64.decode64(@data) : URI.decode(@data)

--- a/test/test_data_open_uri.rb
+++ b/test/test_data_open_uri.rb
@@ -1,8 +1,8 @@
 require 'data_uri'
 require 'open-uri'
 require 'data_uri/open_uri'
-require 'minitest/spec'
 require 'minitest/autorun'
+require 'minitest/spec'
 
 describe URI::Data do
 

--- a/test/test_data_uri.rb
+++ b/test/test_data_uri.rb
@@ -1,6 +1,6 @@
 require 'data_uri'
-require 'minitest/spec'
 require 'minitest/autorun'
+require 'minitest/spec'
 
 describe URI::Data do
 

--- a/test/test_data_uri.rb
+++ b/test/test_data_uri.rb
@@ -91,6 +91,13 @@ describe URI::Data do
 
     end
 
+    describe "an invalid data URI" do
+      it "should raise an error" do
+        proc { URI::Data.new("This is not a data URI") }.must_raise(URI::InvalidURIError)
+        proc { URI::Data.new("data:Neither this") }.must_raise(URI::InvalidURIError)
+      end
+    end
+
   end
 
   describe "building" do

--- a/test/test_data_uri.rb
+++ b/test/test_data_uri.rb
@@ -75,14 +75,18 @@ describe URI::Data do
         @raw = "data:application/octet-stream;base64,#{Base64.encode64(@data).chop}"
       end
 
-      it "shouldn't be parsed by URI.parse because the ABS_URI regexp is silly" do
-        uri = URI.parse(@raw)
-        assert uri.data != @data
+      it "isn't parsed by URI.parse" do
+        if RUBY_VERSION == "1.8.7"
+          uri = URI.parse(@raw)
+          refute_equal uri.data, @data
+        else
+          proc { URI.parse(@raw) }.must_raise(URI::InvalidURIError)
+        end
       end
 
       it "should be parsed by URI::Data.new" do
         uri = URI::Data.new(@raw)
-        assert uri.data == @data
+        assert_equal uri.data, @data
       end
 
     end


### PR DESCRIPTION
This is the change I wanted to make originally :wink: 

Now it raises a specific exception that can be easily rescued, instead of having to rescue it all:

``` ruby
begin
  @uri = URI::Data.new(uri)
rescue URI::InvalidURIError
  # whatever
end
```
