### PR TITLE
Keep this gem available with Ruby 3.1

### DIFF
--- a/lib/data_uri/uri.rb
+++ b/lib/data_uri/uri.rb
@@ -61,6 +61,6 @@ module URI
     end
   end
 
-  @@schemes['DATA'] = Data
+  scheme_list['DATA'] = Data
 
 end


### PR DESCRIPTION
Hi there,

Thanks for this nice gem to use carrierwave-data-uri.

I noticed `require "data_uri"` fails when I upgraded my application to Ruby3.1.
Look like we mustn't use `@@schemes` class variable because the suparclass "URI::Generic" has been changed the specification.(the relevant PR is [here](https://github.com/ruby/uri/commit/1faa4fdc161d7aeebdb5de0c407b923beaecf898)).

If you have any advices, please tell me.
Hope that helps!