### PR TITLE
gemspec: Drop removed directive has_rdoc= (to avoid a Ruby warning)

### DIFF
--- a/data_uri.gemspec
+++ b/data_uri.gemspec
@@ -8,7 +8,6 @@ Gem::Specification.new do |s|
   s.summary     = "A URI class for parsing data URIs as per RFC2397"
 
   s.platform = Gem::Platform::RUBY
-  s.has_rdoc = true
   s.extra_rdoc_files = ["README.rdoc"]
 
   s.require_path = 'lib'


### PR DESCRIPTION
This PR avoids an installation warning (Ruby warning).

"NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed in Rubygems 4"