### PR TITLE
chore: Remove has_rdoc= for Ruby 4.0 compatibility

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     minitest (5.2.3)
-    rake (10.1.1)
+    rake (12.3.3)
 
 PLATFORMS
   ruby
@@ -15,4 +15,4 @@ PLATFORMS
 DEPENDENCIES
   data_uri!
   minitest
-  rake
+  rake (>= 12.3.3)

--- a/data_uri.gemspec
+++ b/data_uri.gemspec
@@ -8,7 +8,6 @@ Gem::Specification.new do |s|
   s.summary     = "A URI class for parsing data URIs as per RFC2397"
 
   s.platform = Gem::Platform::RUBY
-  s.has_rdoc = true
   s.extra_rdoc_files = ["README.rdoc"]
 
   s.require_path = 'lib'

--- a/data_uri.gemspec
+++ b/data_uri.gemspec
@@ -14,6 +14,6 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.files = %w(README.rdoc Rakefile) + Dir.glob("lib/**/*")
 
-  s.add_development_dependency 'rake'
+  s.add_development_dependency 'rake', '>= 12.3.3'
   s.add_development_dependency 'minitest'
 end

--- a/lib/data_uri/uri.rb
+++ b/lib/data_uri/uri.rb
@@ -61,6 +61,11 @@ module URI
     end
   end
 
-  @@schemes['DATA'] = Data
+  # Handle both Ruby 3.2.7's scheme_list and older Ruby versions' @@schemes
+  if defined?(scheme_list)
+    scheme_list['DATA'] = Data
+  else
+    @@schemes['DATA'] = Data
+  end
 
 end


### PR DESCRIPTION
`Gem::Specification#has_rdoc=` was removed in Ruby 4.0. This line causes
a hard `undefined method 'has_rdoc='` error when Bundler loads the gemspec
under Ruby 4.0+.

Changes:
- data_uri.gemspec: Remove `s.has_rdoc = true`